### PR TITLE
Extended translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ render(
 )
 ```
 
-### translate(displayName[, shouldComponentUpdate])
+### translate(displayName[, shouldComponentUpdate][, fallBackString])
 
 Connects a component to the translations provided by `<TranslatorProvider>`. It passes a `t` function to your component's props. It returns a new, connected component class (i.e., it does not modify the component class passed to it).
 
@@ -48,6 +48,7 @@ Connects a component to the translations provided by `<TranslatorProvider>`. It 
 
 - `displayName` (*String*) Name of the component in the translations. It is required because we cannot rely on the `component.name` with minified code.
 - `shouldComponentUpdate` optional, (*Function*) Custom `shouldComponentUpdate` for the component.
+- If the translation key is not found and `fallBackString` is provided we use this instead.
 
 #### Usage
 
@@ -61,7 +62,7 @@ const Header = ({ t }) => (
 export default translate("Header")(Header)
 ```
 
-### transate([ displayName, childTranslations, ... ][, shouldComponentUpdate]) - extended translations
+### transate([ displayName, childTranslations, ... ][, shouldComponentUpdate][, fallBackString]) - extended translations
 
 You can extend more general translations by providing an array of translation keys to `translate` in order to reduce repetition. Keys to the left have priority and will overwrite any previous translations.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,59 @@ const Header = ({ t }) => (
 export default translate("Header")(Header)
 ```
 
+### transate([ displayName, childTranslations, ... ][, shouldComponentUpdate]) - extended translations
+
+You can extend more general translations by providing an array of translation keys to `translate` in order to reduce repetition. Keys to the left have priority and will overwrite any previous translations.
+
+
+**Translation file:**
+```json
+{
+  "MyComponent": {
+    "Name": "Your name?",
+    "Age": "Your age?"
+  },
+  "PeopleDetails": {
+    "Age": "How old are you?",
+    "Location": "Your location?"
+  }
+}
+```
+
+**Component:**
+```javascript
+const MyComponent = ({ t }) => (
+  <section>
+    <div>
+      {t("Name")}
+    </div>
+    <div>
+      {t("Age")}
+    </div>
+    <div>
+      {t("Location")}
+    </div>
+  </section>
+)
+
+export default translate(["MyComponent","PeopleDetails"])(Header)
+```
+
+This would export as:
+```html
+<section>
+  <div>
+    Your name?
+  </div>
+  <div>
+    Your age?
+  </div>
+  <div>
+    Your location?
+  </div>
+</section>
+```
+
 ### t(key [, params])
 
 The `t` function passed a prop is the one that returns your translations given the key, and optionally some parameters.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const Header = ({ t }) => (
 export default translate("Header")(Header)
 ```
 
-### transate([ displayName, childTranslations, ... ][, shouldComponentUpdate]) - extended translations
+### translate([ displayName, childTranslations, ... ][, shouldComponentUpdate]) - extended translations
 
 You can extend more general translations by providing an array of translation keys to `translate` in order to reduce repetition. Keys to the left have priority and will overwrite any previous translations.
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "author": "bloodyowl",
   "license": "MIT",
   "dependencies": {
-    "invariant": "^2.1.2"
+    "invariant": "^2.1.2",
+    "prop-types": "^15.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-addons-test-utils": "^15.0.0"
   },
   "peerDependencies": {
-    "react": "^15.0.0"
+    "react": "^15.0.0 < 17"
   },
   "scripts": {
     "start": "babel src --out-dir lib --ignore='__tests__'",

--- a/src/TranslatorProvider.js
+++ b/src/TranslatorProvider.js
@@ -1,7 +1,8 @@
-import React, { Component, PropTypes, Children } from "react"
-import createTranslator from "./createTranslator"
+import React, { Component, Children } from 'react'
+import createTranslator from './createTranslator'
+import PropTypes from 'prop-types'
 
-class TranslatorProvider extends Component {
+class TranslatorProvider extends React.Component {
 
   getChildContext() {
     const { translations } = this.props
@@ -12,7 +13,7 @@ class TranslatorProvider extends Component {
   }
 
   render() {
-    return Children.only(this.props.children)
+    return React.Children.only(this.props.children)
   }
 }
 

--- a/src/__tests__/TranslatorProvider-test.js
+++ b/src/__tests__/TranslatorProvider-test.js
@@ -1,11 +1,10 @@
 const TranslatorProvider = require("../TranslatorProvider").default
 const React = require("react")
 const { renderIntoDocument } = require("react-addons-test-utils")
-
-const { Component, PropTypes } = React
+const PropTypes = require('prop-types')
 
 it("TranslatorProvider", () => {
-  class Dummy extends Component {
+  class Dummy extends React.Component {
     render() {
       expect(typeof this.context.translator).toBe("function")
       expect(typeof this.context.locale).toBe("string")

--- a/src/__tests__/translate-test.js
+++ b/src/__tests__/translate-test.js
@@ -65,3 +65,31 @@ it("`t` returns key if not specified", () => {
     </TranslatorProvider>
   )
 })
+
+it("`t` can deal with extended translations", () => {
+  const Dummy = ({ t }) => {
+    expect(typeof t).toBe("function")
+    expect(t("foo")).toBe("parent-foo")
+    expect(t("overwrite")).toBe("overwrite")
+    expect(t("child-translation")).toBe("child-translation")
+    return <div />
+  }
+  const WrappedDummy = translate([ "Dummy", "Child" ])(Dummy)
+  renderIntoDocument(
+    <TranslatorProvider
+      translations={{
+        locale: "en",
+        "Dummy": {
+          "foo": "parent-foo",
+          "overwrite": "overwrite"
+        },
+        "Child": {
+          "overwrite": "child",
+          "child-translation": "child-translation"
+        }
+      }}
+    >
+      <WrappedDummy />
+    </TranslatorProvider>
+  )
+})

--- a/src/__tests__/translate-test.js
+++ b/src/__tests__/translate-test.js
@@ -93,3 +93,22 @@ it("`t` can deal with extended translations", () => {
     </TranslatorProvider>
   )
 })
+
+it("Uses fall back string if key does not exist and string provided", () => {
+  const Dummy = ({ t }) => {
+    const fallBack = 'this is my fall back string'
+    expect(t("foo", undefined, fallBack)).toBe(fallBack)
+    return <div />
+  }
+  const WrappedDummy = translate([ "Dummy" ])(Dummy)
+  renderIntoDocument(
+    <TranslatorProvider
+      translations={{
+        locale: "en",
+        "Dummy": {}
+      }}
+    >
+      <WrappedDummy />
+    </TranslatorProvider>
+  )
+})

--- a/src/__tests__/translate-test.js
+++ b/src/__tests__/translate-test.js
@@ -112,3 +112,23 @@ it("Uses fall back string if key does not exist and string provided", () => {
     </TranslatorProvider>
   )
 })
+
+it("Uses fall back string if key does not exist and string provided", () => {
+  const Dummy = ({ t }) => {
+    const fallBack = 'this is my fall back string'
+    expect(t("foo", undefined, fallBack)).toBe(fallBack)
+    return <div />
+  }
+  const WrappedDummy = translate([ "Dummy", "Child" ])(Dummy)
+  renderIntoDocument(
+    <TranslatorProvider
+      translations={{
+        locale: "en",
+        "Dummy": {},
+        "Child": {}
+      }}
+    >
+      <WrappedDummy />
+    </TranslatorProvider>
+  )
+})

--- a/src/createTranslator.js
+++ b/src/createTranslator.js
@@ -12,6 +12,9 @@ const createTranslator = (keys) => {
     if ((1 === componentNames.length) &&
       (false === keys.hasOwnProperty(componentNames[0]))
     ) {
+      if (fallBackString !== undefined) {
+        return () => fallBackString
+      }
       return (key) => `${componentNames[0]}.${key}`
     }
 
@@ -21,6 +24,9 @@ const createTranslator = (keys) => {
     return (key, params) => {
       let translation = componentKeys[key]
       if (translation === undefined) {
+        if (fallBackString !== undefined) {
+          return fallBackString
+        }
         return `${componentNames[0]}.${key}`
       }
       if(Array.isArray(translation)) {

--- a/src/createTranslator.js
+++ b/src/createTranslator.js
@@ -4,14 +4,24 @@ import getPluralType from "./getPluralType"
 const createTranslator = (keys) => {
   const pluralType = getPluralType(keys.locale)
   return (componentName) => {
-    if (!keys.hasOwnProperty(componentName)) {
-      return (key) => `${componentName}.${key}`
+
+    const componentNames = (false === Array.isArray(componentName))
+      ? [ componentName ]
+      : componentName
+
+    if ((1 === componentNames.length) &&
+      (false === keys.hasOwnProperty(componentNames[0]))
+    ) {
+      return (key) => `${componentNames[0]}.${key}`
     }
-    const componentKeys = keys[componentName]
+
+    const componentKeys = componentNames.reverse().reduce((translations, name) => {
+      return Object.assign(translations, keys[name])
+    }, {})
     return (key, params) => {
       let translation = componentKeys[key]
       if (translation === undefined) {
-        return `${componentName}.${key}`
+        return `${componentNames[0]}.${key}`
       }
       if(Array.isArray(translation)) {
         // plural

--- a/src/createTranslator.js
+++ b/src/createTranslator.js
@@ -3,7 +3,7 @@ import getPluralType from "./getPluralType"
 
 const createTranslator = (keys) => {
   const pluralType = getPluralType(keys.locale)
-  return (componentName) => {
+  return (componentName, fallBackString) => {
 
     const componentNames = (false === Array.isArray(componentName))
       ? [ componentName ]
@@ -12,16 +12,18 @@ const createTranslator = (keys) => {
     if ((1 === componentNames.length) &&
       (false === keys.hasOwnProperty(componentNames[0]))
     ) {
-      if (fallBackString !== undefined) {
-        return () => fallBackString
+      return (key) => {
+        if ((componentNames[0].key === undefined) && (fallBackString !== undefined)) {
+          return fallBackString
+        }
+        return `${componentNames[0]}.${key}`
       }
-      return (key) => `${componentNames[0]}.${key}`
     }
 
     const componentKeys = componentNames.reverse().reduce((translations, name) => {
       return Object.assign(translations, keys[name])
     }, {})
-    return (key, params) => {
+    return (key, params, fallBackString) => {
       let translation = componentKeys[key]
       if (translation === undefined) {
         if (fallBackString !== undefined) {

--- a/src/translate.js
+++ b/src/translate.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export default function translate(displayName, shouldComponentUpdate) {
+export default function translate(displayName, shouldComponentUpdate, fallBackString) {
   let t
   let previousLocale = null
   return (ChildComponent) => {
@@ -16,7 +16,7 @@ export default function translate(displayName, shouldComponentUpdate) {
         render() {
           const { translator, locale } = this.context
           if(locale !== previousLocale) {
-            t = translator(displayName)
+            t = translator(displayName, fallBackString)
             previousLocale = locale
           }
           return (

--- a/src/translate.js
+++ b/src/translate.js
@@ -15,8 +15,8 @@ export default function translate(displayName, shouldComponentUpdate, fallBackSt
 
         render() {
           const { translator, locale } = this.context
-          if(locale !== previousLocale) {
-            t = translator(displayName, fallBackString)
+          if (locale !== previousLocale) {
+            t = translator(displayName)
             previousLocale = locale
           }
           return (

--- a/src/translate.js
+++ b/src/translate.js
@@ -1,11 +1,12 @@
-import React, { Component, PropTypes } from "react"
+import React from 'react'
+import PropTypes from 'prop-types'
 
 export default function translate(displayName, shouldComponentUpdate) {
   let t
   let previousLocale = null
   return (ChildComponent) => {
 
-     class Translator extends Component {
+     class Translator extends React.Component {
 
         constructor(props, context) {
           super(props, context)


### PR DESCRIPTION
Support 'extended' translations by supplying an array as the component name. Readme updated with information, non-backwards breaking change. 

This saves us from duplication in translation files with the left-most key taking priority. 