### PR TITLE
Added support for SK plural types - they are the same as CZECH

### DIFF
--- a/src/pluralMap.js
+++ b/src/pluralMap.js
@@ -36,6 +36,7 @@ const pluralMap = {
   ru: RUSSIAN,
 
   cs: CZECH,
+  sk: CZECH,
 
   pl: POLISH,
 


### PR DESCRIPTION
There is missing support for plural types in SK language, but plural types are the same as types in Czech.

> 1 (one) - nominative case singular, for example jeden dub (one oak)
> 2, 3, 4 - nominative case plural, for example dva duby (two oaks)
> 0, 5 and more - genitive case plural, for example päť dubov (five [of] oaks)

(https://en.wikipedia.org/wiki/Slovak_declension)